### PR TITLE
Fix the sbt version number with Giter8 new command.

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-All templates are based on Giter8 , make sure you installed `sbt 0.13.3` or above on your machine.
+All templates are based on Giter8 , make sure you installed `sbt 0.13.13` or above on your machine.
 
 Which app you want to build ? 
 


### PR DESCRIPTION
According to the official document,
http://www.foundweekends.org/giter8/, sbt supports "new" command from
v0.13.13.